### PR TITLE
Rest security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/logs/
 !.mvn/wrapper/maven-wrapper.jar
 
 ### STS ###
@@ -23,3 +24,6 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+
+
+

--- a/src/main/java/com/geekbrains/geekmarket/config/SecurityConfig.java
+++ b/src/main/java/com/geekbrains/geekmarket/config/SecurityConfig.java
@@ -53,8 +53,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .loginProcessingUrl("/authenticateTheUser")
                 .successHandler(customAuthenticationSuccessHandler)
                 .permitAll()
-                .and()
-                .csrf().ignoringAntMatchers("/api/**");
+                .and();
+//                .csrf().ignoringAntMatchers("/api/**");
     }
 
     @Bean

--- a/src/main/resources/static/js/all-pages.js
+++ b/src/main/resources/static/js/all-pages.js
@@ -1,0 +1,7 @@
+var token;
+var header;
+
+$(document).ready(function () {
+    token = $("meta[name='_csrf']").attr("content");
+    header = $("meta[name='_csrf_header']").attr("content");
+});

--- a/src/main/resources/static/js/cart-dt.js
+++ b/src/main/resources/static/js/cart-dt.js
@@ -1,55 +1,58 @@
 // https://datatables.net/
 
-$(document).ready( function () {
-    var getTotalCost = function() {
+$(document).ready(function () {
+    var getTotalCost = function () {
         var res = $.ajax({
-          type: "GET",
-          url: "/geekmarket/api/cart_items/cost",
-          async: false
-        }).done(function(data) {
-          return data;
+            type: "GET",
+            url: "/geekmarket/api/cart_items/cost",
+            async: false
+        }).done(function (data) {
+            return data;
         });
         console.log(res);
         return res;
     }
 
-	 var table = $('.table').DataTable({
-	    "ajax": {
-	      "url": "/geekmarket/api/cart_items",
-	      "dataSrc": ""
-	    },
+    var table = $('.table').DataTable({
+        "ajax": {
+            "url": "/geekmarket/api/cart_items",
+            "dataSrc": ""
+        },
         "columns": [
-            { "data": "product.title" },
+            {"data": "product.title"},
             {
-              "data": null,
-              "render": function (data, type, row) {
-                return '<input type="number" class="qnt-changer" min=1 ord_product_id="' + row.product.id + '" value="' + row.quantity + '"></input>';
-              }
+                "data": null,
+                "render": function (data, type, row) {
+                    return '<input type="number" class="qnt-changer" min=1 ord_product_id="' + row.product.id + '" value="' + row.quantity + '"></input>';
+                }
             },
-            { "data": "totalPrice" }
-        ] ,
-        "initComplete": function(settings, json) {
-          $('#totalCost').text('Итоговая сумма: ' + getTotalCost().responseText);
+            {"data": "totalPrice"}
+        ],
+        "initComplete": function (settings, json) {
+            $('#totalCost').text('Итоговая сумма: ' + getTotalCost().responseText);
         }
 //        "drawCallback": function(settings) {
 //          $('#totalCost').text('Итоговая сумма: ' + getTotalCost().responseText);
 //          initAllChangers();
 //        }
-	 })
+    })
 
-    $('.table').on('click', '.qnt-changer', function() {
-       $.ajax({
-          type: "PUT",
-          url: "/geekmarket/api/cart_items",
-          async: false,
-          data: {
-            'product_id': $(this).attr('ord_product_id'),
-            'quantity': $(this).val()
-          }
-       }).done(function() {
-          table.ajax.reload();
-       });
-       $('#totalCost').text('Итоговая сумма: ' + getTotalCost().responseText);
+    $('.table').on('click', '.qnt-changer', function () {
+        $.ajax({
+            type: "PUT",
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader(header, token);
+            },
+            url: "/geekmarket/api/cart_items",
+            async: false,
+            data: {
+                'product_id': $(this).attr('ord_product_id'),
+                'quantity': $(this).val()
+            }
+        }).done(function () {
+            table.ajax.reload();
+        });
+        $('#totalCost').text('Итоговая сумма: ' + getTotalCost().responseText);
     });
 
 //	 var initAllChangers = function() {

--- a/src/main/resources/static/js/datatable.js
+++ b/src/main/resources/static/js/datatable.js
@@ -1,39 +1,42 @@
 // https://datatables.net/
 
-$(document).ready( function () {
-	 var table = $('.table').DataTable({
-	    "ajax": {
-	      "url": "/geekmarket/api/products",
-	      "dataSrc": "" //,
+$(document).ready(function () {
+    var table = $('.table').DataTable({
+        "ajax": {
+            "url": "/geekmarket/api/products",
+            "dataSrc": "" //,
 //	      "type": "POST"
-	    },
+        },
 //	      "processing": true,
 //        "serverSide": true,
         "columns": [
-            { "data": "id" },
-            { "data": "title" },
-            { "data": "price" },
+            {"data": "id"},
+            {"data": "title"},
+            {"data": "price"},
             {
-              "data": "id",
-              "render": function (data, type, full, meta) {
-                return '<button type="button" class="btn btn-primary add-item-btn" link="' + data + '">Купить</button>';
-              }
+                "data": "id",
+                "render": function (data, type, full, meta) {
+                    return '<button type="button" class="btn btn-primary add-item-btn" link="' + data + '">Купить</button>';
+                }
             }
         ],
-        "initComplete": function(settings, json) {
-          $('.add-item-btn').on('click', function(event) {
-            var btnLink = $(this).attr('link');
-            // console.log(btnLink);
-            $.ajax({
-              url: "/geekmarket/api/cart_items",
-              type: "POST",
-              data: {
-                "id": btnLink
-              }
-            }).done(function() {
-              alert("Товар добавлен в корзину");
+        "initComplete": function (settings, json) {
+            $('.add-item-btn').on('click', function (event) {
+                var btnLink = $(this).attr('link');
+                // console.log(btnLink);
+                $.ajax({
+                    url: "/geekmarket/api/cart_items",
+                    type: "POST",
+                    beforeSend: function (xhr) {
+                        xhr.setRequestHeader(header, token);
+                    },
+                    data: {
+                        "id": btnLink
+                    }
+                }).done(function () {
+                    alert("Товар добавлен в корзину");
+                });
             });
-          });
         }
-	 })
+    })
 });

--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8"/>
     <title>Ajax Shop Page</title>
-
+    <meta th:name="_csrf" th:content="${_csrf.token}"/>
+    <meta th:name="_csrf_header" th:content="${_csrf.headerName}"/>
     <!--<script type="text/javascript" th:src="@{/webjars/jquery/3.3.1/dist/jquery.min.js}"></script>-->
     <!--<script type="text/javascript" th:src="@{/webjars/bootstrap/4.1.3/js/bootstrap.min.js}"></script>-->
     <!--<link type="text/css" rel="stylesheet" th:href="@{/webjars/bootstrap/4.1.3/css/bootstrap.min.css}"/>-->
@@ -13,6 +14,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" th:src="@{/js/all-pages.js}"></script>
     <script type="text/javascript" th:src="@{/js/cart-dt.js}"></script>
 
 </head>

--- a/src/main/resources/templates/shop-page.html
+++ b/src/main/resources/templates/shop-page.html
@@ -2,6 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="utf-8"/>
+    <meta th:name="_csrf" th:content="${_csrf.token}"/>
+    <meta th:name="_csrf_header" th:content="${_csrf.headerName}"/>
     <title>Ajax Shop Page</title>
 
     <!--<script type="text/javascript" th:src="@{/webjars/jquery/3.3.1/dist/jquery.min.js}"></script>-->
@@ -13,6 +15,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
     <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" th:src="@{/js/all-pages.js}"></script>
     <script type="text/javascript" th:src="@{/js/datatable.js}"></script>
 
 </head>


### PR DESCRIPTION
1. В SecurityConfig.class закомментирован костыль .csrf().ignoringAntMatchers("/api/**");
2. На Thymleaf страницах, использующих ajax не get запросы добавлены метатеги
```
    <meta th:name="_csrf" th:content="${_csrf.token}"/>
    <meta th:name="_csrf_header" th:content="${_csrf.headerName}"/>
```
и ссылка на скипт all-pages.js
3.  Добавлен скрипт all-pages.js, который отвечате за извлечение переменных из метатегов.
4. В AJAX не на get запросах добавлен токен в заголовок сообщения
```
                    beforeSend: function (xhr) {
                        xhr.setRequestHeader(header, token);
                    },
```